### PR TITLE
Replaced tk-unreal descriptor with a github_release

### DIFF
--- a/env/includes/unreal/tk-unreal-location.yml
+++ b/env/includes/unreal/tk-unreal-location.yml
@@ -6,6 +6,7 @@
 
 tk-unreal.location:
   version: v1.2.3
-  type: git
-  path: git@github.com:GPLgithub/tk-unreal.git
-#  path: git@github.com:ue4plugins/tk-unreal.git
+  type: github_release
+  organization: GPLgithub
+#  organization: ue4plugins
+  repository: tk-unreal

--- a/env/includes/unreal/tk-unreal-location.yml
+++ b/env/includes/unreal/tk-unreal-location.yml
@@ -7,6 +7,5 @@
 tk-unreal.location:
   version: v1.2.3
   type: github_release
-  organization: GPLgithub
-#  organization: ue4plugins
+  organization: ue4plugins
   repository: tk-unreal


### PR DESCRIPTION
Git descriptors requires git to be locally installed and valid git credentials, github_release don't.