### PR TITLE
Latest Unreal Engine and Framework and small fixes

### DIFF
--- a/core/core_api.yml
+++ b/core/core_api.yml
@@ -14,4 +14,4 @@
 location:
   type: app_store
   name: tk-core
-  version: v0.20.10
+  version: v0.20.11

--- a/core/core_api.yml
+++ b/core/core_api.yml
@@ -14,4 +14,4 @@
 location:
   type: app_store
   name: tk-core
-  version: v0.20.8
+  version: v0.20.9

--- a/core/core_api.yml
+++ b/core/core_api.yml
@@ -14,4 +14,4 @@
 location:
   type: app_store
   name: tk-core
-  version: v0.20.9
+  version: v0.20.10

--- a/core/core_api.yml
+++ b/core/core_api.yml
@@ -14,4 +14,4 @@
 location:
   type: app_store
   name: tk-core
-  version: v0.20.8
+  version: v0.20.11

--- a/env/asset_step.yml
+++ b/env/asset_step.yml
@@ -42,4 +42,6 @@ engines:
   tk-alias: '@alias.asset_step'
   tk-vred: '@vred.asset_step'
   tk-shotgun: '@shotgun.all'
-  tk-unreal: "@settings.tk-unreal.asset_step"
+  # Disabled for now since there is nothing specific
+  # for Asset step in tk-unreal at the moment.
+  # tk-unreal: "@settings.tk-unreal.asset_step"

--- a/env/asset_step.yml
+++ b/env/asset_step.yml
@@ -25,7 +25,6 @@ includes:
 - includes/alias/asset_step.yml
 - includes/vred/asset_step.yml
 - includes/shotgun/all.yml
-- includes/unreal/settings/tk-unreal.yml
 
 engines:
   tk-desktop2: '@desktop2.all'
@@ -42,6 +41,3 @@ engines:
   tk-alias: '@alias.asset_step'
   tk-vred: '@vred.asset_step'
   tk-shotgun: '@shotgun.all'
-  # Disabled for now since there is nothing specific
-  # for Asset step in tk-unreal at the moment.
-  # tk-unreal: "@settings.tk-unreal.asset_step"

--- a/env/includes/alias/apps.yml
+++ b/env/includes/alias/apps.yml
@@ -28,10 +28,10 @@ alias.apps.tk-multi-publish2:
   - name: Publish to ShotGrid
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py"
     settings: {}
-  - name: Create 3D Version for Review
+  - name: Create Version for Review
     hook: "{self}/upload_version.py:{engine}/tk-multi-publish2/basic/upload_version.py"
     settings:
-      3D Version: True
+      Version Type: 2D Version
   - name: Publish Variants to ShotGrid
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_variants.py"
     settings: {}

--- a/env/includes/alias/asset_step.yml
+++ b/env/includes/alias/asset_step.yml
@@ -21,12 +21,13 @@ alias.asset_step:
   apps:
     tk-multi-about: '@common.apps.tk-multi-about'
 
+    tk-multi-pythonconsole: '@common.apps.tk-multi-pythonconsole'
+
     tk-multi-publish2: '@alias.apps.tk-multi-publish2'
 
     tk-multi-loader2: '@alias.apps.tk-multi-loader2'
 
     tk-multi-shotgunpanel: '@alias.apps.tk-multi-shotgunpanel'
-
 
   location: "@common.engines.tk-alias.location"
   menu_favourites: []

--- a/env/includes/alias/project.yml
+++ b/env/includes/alias/project.yml
@@ -22,6 +22,8 @@ alias.project:
   apps:
     tk-multi-about: '@common.apps.tk-multi-about'
 
+    tk-multi-pythonconsole: '@common.apps.tk-multi-pythonconsole'
+
     tk-multi-publish2: '@alias.apps.tk-multi-publish2'
 
     tk-multi-loader2: '@alias.apps.tk-multi-loader2'

--- a/env/includes/alias/site.yml
+++ b/env/includes/alias/site.yml
@@ -22,6 +22,8 @@ alias.site:
 
     tk-multi-about: '@common.apps.tk-multi-about'
 
+    tk-multi-pythonconsole: '@common.apps.tk-multi-pythonconsole'
+
     tk-multi-loader2:
       action_mappings:
         Alias File: [import, import_as_reference]

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -47,7 +47,7 @@ common.engines.tk-flame.location:
 common.engines.tk-alias.location:
   type: app_store
   name: tk-alias
-  version: v2.1.2
+  version: v2.1.3
 common.engines.tk-vred.location:
   type: app_store
   name: tk-vred

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -55,7 +55,7 @@ common.engines.tk-vred.location:
 common.engines.tk-desktop.location:
   type: app_store
   name: tk-desktop
-  version: v2.6.1
+  version: v2.6.2
 common.engines.tk-desktop2.location:
   type: app_store
   name: tk-desktop2

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -51,7 +51,7 @@ common.engines.tk-alias.location:
 common.engines.tk-vred.location:
   type: app_store
   name: tk-vred
-  version: v2.1.2
+  version: v2.1.3
 common.engines.tk-desktop.location:
   type: app_store
   name: tk-desktop

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -31,7 +31,7 @@ common.engines.tk-maya.location:
 common.engines.tk-nuke.location:
   type: app_store
   name: tk-nuke
-  version: v0.14.2
+  version: v0.14.3
 common.engines.tk-photoshopcc.location:
   type: app_store
   name: tk-photoshopcc

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -31,7 +31,7 @@ common.engines.tk-maya.location:
 common.engines.tk-nuke.location:
   type: app_store
   name: tk-nuke
-  version: v0.14.2
+  version: v0.14.3
 common.engines.tk-photoshopcc.location:
   type: app_store
   name: tk-photoshopcc
@@ -47,15 +47,15 @@ common.engines.tk-flame.location:
 common.engines.tk-alias.location:
   type: app_store
   name: tk-alias
-  version: v2.1.2
+  version: v2.1.3
 common.engines.tk-vred.location:
   type: app_store
   name: tk-vred
-  version: v2.1.2
+  version: v2.1.3
 common.engines.tk-desktop.location:
   type: app_store
   name: tk-desktop
-  version: v2.6.1
+  version: v2.6.2
 common.engines.tk-desktop2.location:
   type: app_store
   name: tk-desktop2

--- a/env/includes/maya/apps.yml
+++ b/env/includes/maya/apps.yml
@@ -35,9 +35,11 @@ maya.apps.tk-multi-loader2:
     Alembic Cache: [reference, import]
     Image: [texture_node, image_plane]
     Maya Scene: [reference, import]
+    Maya FBX: [reference, import]
     Photoshop Image: [texture_node, image_plane]
     Rendered Image: [texture_node, image_plane]
     Texture: [texture_node, image_plane]
+    Unreal FBX: [reference, import]
   actions_hook: '{self}/tk-maya_actions.py'
   entities:
   - caption: Current Project
@@ -68,12 +70,16 @@ maya.apps.tk-multi-shotgunpanel:
       filters: {published_file_type: Image}
     - actions: [reference, import]
       filters: {published_file_type: Maya Scene}
+    - actions: [reference, import]
+      filters: {published_file_type: Maya FBX}
     - actions: [texture_node, image_plane]
       filters: {published_file_type: Photoshop Image}
     - actions: [texture_node, image_plane]
       filters: {published_file_type: Rendered Image}
     - actions: [texture_node, image_plane]
       filters: {published_file_type: Texture}
+    - actions: [reference, import]
+      filters: {published_file_type: Unreal FBX}
     - actions: [publish_clipboard]
       filters: {}
     Task:

--- a/env/includes/unreal/frameworks.yml
+++ b/env/includes/unreal/frameworks.yml
@@ -6,7 +6,7 @@
 frameworks:
     tk-framework-unrealqt_v1.x.x:
       location:
-        version: v1.2.5
+        version: v1.2.6
         type: git
         path: git@github.com:GPLgithub/tk-framework-unrealqt.git
 #        path: git@github.com:ue4plugins/tk-framework-unrealqt.git

--- a/env/includes/unreal/frameworks.yml
+++ b/env/includes/unreal/frameworks.yml
@@ -6,7 +6,7 @@
 frameworks:
     tk-framework-unrealqt_v1.x.x:
       location:
-        version: v1.2.6
+        version: v1.2.7
         type: git
         path: git@github.com:GPLgithub/tk-framework-unrealqt.git
 #        path: git@github.com:ue4plugins/tk-framework-unrealqt.git

--- a/env/includes/unreal/frameworks.yml
+++ b/env/includes/unreal/frameworks.yml
@@ -6,7 +6,7 @@
 frameworks:
     tk-framework-unrealqt_v1.x.x:
       location:
-        version: v1.2.7
+        version: v1.2.8
         type: git
         path: git@github.com:GPLgithub/tk-framework-unrealqt.git
 #        path: git@github.com:ue4plugins/tk-framework-unrealqt.git

--- a/env/includes/unreal/settings/tk-multi-shotgunpanel.yml
+++ b/env/includes/unreal/settings/tk-multi-shotgunpanel.yml
@@ -7,7 +7,11 @@ includes:
 
 settings.tk-multi-shotgunpanel.unreal:
   actions_hook: '{self}/general_actions.py:{engine}/tk-multi-shotgunpanel/tk-unreal_actions.py'
-  action_mappings: {}
-  enable_context_switch: true
+  action_mappings:
+    PublishedFile:
+    - actions: [publish_clipboard]
+      filters: {}
+  # Disable context switching since we only have a Project context.
+  enable_context_switch: false
   location: "@common.apps.tk-multi-shotgunpanel.location"
 

--- a/env/includes/unreal/settings/tk-unreal.yml
+++ b/env/includes/unreal/settings/tk-unreal.yml
@@ -14,16 +14,6 @@ includes:
 
 ################################################################################
 
-# asset_step
-settings.tk-unreal.asset_step:
-  apps:
-    tk-multi-about: '@common.apps.tk-multi-about'
-    tk-multi-pythonconsole: '@common.apps.tk-multi-pythonconsole'
-  location: "@tk-unreal.location"
-  menu_favourites: []
-  run_at_startup: []
-  launch_builtin_plugins: [basic]
-  automatic_context_switch: false
 
 # project
 settings.tk-unreal.project:
@@ -39,3 +29,4 @@ settings.tk-unreal.project:
   - {app_instance: tk-multi-shotgunpanel, name: ''}
   launch_builtin_plugins: [basic]
   automatic_context_switch: false
+ 

--- a/env/includes/unreal/templates.yml
+++ b/env/includes/unreal/templates.yml
@@ -17,7 +17,7 @@ keys:
         type: str
     name:
         type: str
-        filter_by: alphanumeric
+        filter_by: '^[a-zA-Z0-9_-]+$'
     iteration:
         type: int
     version:

--- a/env/includes/unreal/tk-unreal-location.yml
+++ b/env/includes/unreal/tk-unreal-location.yml
@@ -7,5 +7,6 @@
 tk-unreal.location:
   version: v1.2.3
   type: github_release
-  organization: ue4plugins
+#  organization: ue4plugins
+  organization: GPLgithub
   repository: tk-unreal

--- a/env/includes/unreal/tk-unreal-location.yml
+++ b/env/includes/unreal/tk-unreal-location.yml
@@ -5,7 +5,7 @@
 
 
 tk-unreal.location:
-  version: v1.2.3
+  version: v1.2.7
   type: github_release
 #  organization: ue4plugins
   organization: GPLgithub

--- a/env/includes/vred/apps.yml
+++ b/env/includes/vred/apps.yml
@@ -42,15 +42,15 @@ vred.apps.tk-multi-publish2:
 
 vred.apps.tk-multi-loader2:
   action_mappings:
-    Alias File: [import]
-    Igs File: [import]
-    Stp File: [import]
-    Stl File: [import]
-    Jt File: [import]
-    Catpart File: [import]
-    Fbx File: [import]
-    VRED Scene: [import]
-    Osb File: [import]
+    Alias File: [import, import_with_options, smart_reference]
+    Igs File: [import, import_with_options, smart_reference]
+    Stp File: [import, import_with_options, smart_reference]
+    Stl File: [import, import_with_options, smart_reference]
+    Jt File: [import, import_with_options, smart_reference]
+    Catpart File: [import, import_with_options, smart_reference]
+    Fbx File: [import, import_with_options, smart_reference]
+    VRED Scene: [import, import_with_options, smart_reference]
+    Osb File: [import, import_with_options, smart_reference]
     Image: [ import_sceneplate ]
     Rendered Image: [ import_sceneplate ]
   actions_hook: "{engine}/tk-multi-loader2/basic/scene_actions.py"

--- a/env/includes/vred/apps.yml
+++ b/env/includes/vred/apps.yml
@@ -28,10 +28,10 @@ vred.apps.tk-multi-publish2:
   - name: Publish to ShotGrid
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py"
     settings: {}
-  - name: Create 2D Version for Review
+  - name: Create Version for Review
     hook: "{self}/upload_version.py:{engine}/tk-multi-publish2/basic/upload_session_version.py"
     settings:
-      3D Version: False
+      Version Type: 2D Version
   - name: Publish Rendering to ShotGrid
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_rendering.py"
     settings: {}

--- a/env/includes/vred/apps.yml
+++ b/env/includes/vred/apps.yml
@@ -28,10 +28,10 @@ vred.apps.tk-multi-publish2:
   - name: Publish to ShotGrid
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py"
     settings: {}
-  - name: Create 2D Version for Review
+  - name: Create Version for Review
     hook: "{self}/upload_version.py:{engine}/tk-multi-publish2/basic/upload_session_version.py"
     settings:
-      3D Version: False
+      Version Type: 2D Version
   - name: Publish Rendering to ShotGrid
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_rendering.py"
     settings: {}
@@ -42,15 +42,15 @@ vred.apps.tk-multi-publish2:
 
 vred.apps.tk-multi-loader2:
   action_mappings:
-    Alias File: [import]
-    Igs File: [import]
-    Stp File: [import]
-    Stl File: [import]
-    Jt File: [import]
-    Catpart File: [import]
-    Fbx File: [import]
-    VRED Scene: [import]
-    Osb File: [import]
+    Alias File: [import, import_with_options, smart_reference]
+    Igs File: [import, import_with_options, smart_reference]
+    Stp File: [import, import_with_options, smart_reference]
+    Stl File: [import, import_with_options, smart_reference]
+    Jt File: [import, import_with_options, smart_reference]
+    Catpart File: [import, import_with_options, smart_reference]
+    Fbx File: [import, import_with_options, smart_reference]
+    VRED Scene: [import, import_with_options, smart_reference]
+    Osb File: [import, import_with_options, smart_reference]
     Image: [ import_sceneplate ]
     Rendered Image: [ import_sceneplate ]
   actions_hook: "{engine}/tk-multi-loader2/basic/scene_actions.py"

--- a/env/includes/vred/asset_step.yml
+++ b/env/includes/vred/asset_step.yml
@@ -21,6 +21,8 @@ vred.asset_step:
   apps:
     tk-multi-about: '@common.apps.tk-multi-about'
 
+    tk-multi-pythonconsole: '@common.apps.tk-multi-pythonconsole'
+
     tk-multi-publish2: '@vred.apps.tk-multi-publish2'
 
     tk-multi-loader2: '@vred.apps.tk-multi-loader2'
@@ -32,5 +34,13 @@ vred.asset_step:
   menu_favourites: []
   run_at_startup:
   - {app_instance: tk-multi-shotgunpanel, name: ''}
+  - {app_instance: tk-multi-pythonconsole, name: 'ShotGrid Python Console...'}
+  docked_apps:
+    tk-multi-shotgunpanel:
+        pos: right
+        tabbed: True
+    tk-multi-pythonconsole:
+        pos: right
+        tabbed: True
   launch_builtin_plugins: [basic]
   automatic_context_switch: false

--- a/env/includes/vred/project.yml
+++ b/env/includes/vred/project.yml
@@ -22,6 +22,8 @@ vred.project:
   apps:
     tk-multi-about: '@common.apps.tk-multi-about'
 
+    tk-multi-pythonconsole: '@common.apps.tk-multi-pythonconsole'
+
     tk-multi-publish2: '@vred.apps.tk-multi-publish2'
 
     tk-multi-loader2: '@vred.apps.tk-multi-loader2'
@@ -32,6 +34,14 @@ vred.project:
   menu_favourites: []
   run_at_startup:
   - {app_instance: tk-multi-shotgunpanel, name: ''}
+  - {app_instance: tk-multi-pythonconsole, name: 'ShotGrid Python Console...'}
+  docked_apps:
+    tk-multi-shotgunpanel:
+        pos: right
+        tabbed: True
+    tk-multi-pythonconsole:
+        pos: right
+        tabbed: True
   accepted_published_file_types: [ VRED Scene, Alias File, Catpart File, Jt File, Igs File ]
   launch_builtin_plugins: [basic]
   automatic_context_switch: false

--- a/env/includes/vred/site.yml
+++ b/env/includes/vred/site.yml
@@ -22,6 +22,8 @@ vred.site:
 
     tk-multi-about: '@common.apps.tk-multi-about'
 
+    tk-multi-pythonconsole: '@common.apps.tk-multi-pythonconsole'
+
     tk-multi-loader2:
       action_mappings:
         Alias File: [import]
@@ -60,5 +62,13 @@ vred.site:
   menu_favourites: []
   run_at_startup:
   - {app_instance: tk-multi-shotgunpanel, name: ''}
+  - {app_instance: tk-multi-pythonconsole, name: 'ShotGrid Python Console...'}
+  docked_apps:
+    tk-multi-shotgunpanel:
+        pos: right
+        tabbed: True
+    tk-multi-pythonconsole:
+        pos: right
+        tabbed: True
   launch_builtin_plugins: [basic]
   automatic_context_switch: false


### PR DESCRIPTION
Updated Unreal engine to v1.2.7
Updated Unreal qt framework to v1.2.8
Disabled asset step context for now
Allowed asset names to include letters, numbers, "-" and "_".
Allowed FBX to be imported or referenced in Maya.
Removed Unreal asset step not used anymore.
Updated from base v1.4.4 basic config.