### PR TITLE
Github release descriptor, updates from TK basic v1.4.5, tk-framework-unrealqt v1.3.0

### DIFF
--- a/core/core_api.yml
+++ b/core/core_api.yml
@@ -14,4 +14,4 @@
 location:
   type: app_store
   name: tk-core
-  version: v0.20.11
+  version: v0.20.12

--- a/core/hooks/bootstrap.py
+++ b/core/hooks/bootstrap.py
@@ -54,11 +54,7 @@ class Bootstrap(get_hook_baseclass()):
         :raises RuntimeError: If six.moves is not available.
         """
         descd = descriptor.get_dict()
-        # Some descriptors like shotgun descriptors don't have a path: ignore
-        # them.
-        if not descd.get("path"):
-            return False
-        return bool(self._should_download_release(descd["path"]))
+        return bool(self._should_download_release(descd))
 
     def populate_bundle_cache_entry(self, destination, descriptor, **kwargs):
         """
@@ -92,7 +88,7 @@ class Bootstrap(get_hook_baseclass()):
         descd = descriptor.get_dict()
         version = descriptor.version
         self.logger.info("Treating %s" % descd)
-        specs = self._should_download_release(descd["path"])
+        specs = self._should_download_release(descd)
         if not specs:
             raise RuntimeError("Don't know how to download %s" % descd)
         name = specs[0]
@@ -171,17 +167,28 @@ class Bootstrap(get_hook_baseclass()):
             self.logger.exception(e)
             raise
 
-    def _should_download_release(self, desc_path):
+    def _should_download_release(self, desc):
         """
-        Return a repo name and a token if the given descriptor path should be downloaded
+        Return a repo name and a token if the given descriptor should be downloaded
         from a github release.
 
-        :param str desc_path: A Toolkit descriptor path.
+        :param str desc: A Toolkit descriptor.
         :returns: A name, token tuple or ``None``.
         """
-        for name, token in self._download_release_from_github:
-            if "git@github.com:%s.git" % name == desc_path:
-                return name, token
+        if desc["type"] == "github_release":
+            # Let's be safe...
+            if not desc.get("organization") or not desc.get("repository"):
+                return None
+            desc_path = "%s/%s" % (desc["organization"], desc["repository"])
+            for name, token in self._download_release_from_github:
+                if name == desc_path:
+                    return name, token
+        elif desc.get("path"):
+            # Check the path for a git descriptor
+            desc_path = desc["path"]
+            for name, token in self._download_release_from_github:
+                if "git@github.com:%s.git" % name == desc_path:
+                    return name, token
         return None
 
     def _download_zip_github_asset(self, asset, destination, token):

--- a/core/hooks/bootstrap.py
+++ b/core/hooks/bootstrap.py
@@ -138,7 +138,7 @@ class Bootstrap(get_hook_baseclass()):
             for asset in response_d["assets"]:
                 name = asset["name"]
                 m = re.match(
-                    "%s-py\d.\d-%s.zip" % (version, pname),
+                    r"%s-py\d.\d-%s.zip" % (version, pname),
                     name
                 )
                 if m:

--- a/env/includes/common/apps.yml
+++ b/env/includes/common/apps.yml
@@ -19,7 +19,7 @@ includes:
 
 common.apps.tk-multi-about:
   location:
-    version: v0.4.1
+    version: v0.4.2
     type: app_store
     name: tk-multi-about
 common.apps.tk-multi-pythonconsole:
@@ -35,19 +35,19 @@ common.apps.tk-multi-setframerange:
 common.apps.tk-multi-publish2.location:
   type: app_store
   name: tk-multi-publish2
-  version: v2.6.1
+  version: v2.6.2
 common.apps.tk-multi-loader2.location:
   type: app_store
   name: tk-multi-loader2
-  version: v1.21.1
+  version: v1.21.2
 common.apps.tk-multi-shotgunpanel.location:
   type: app_store
   name: tk-multi-shotgunpanel
-  version: v1.8.1
+  version: v1.8.2
 common.apps.tk-multi-launchapp.location:
   type: app_store
   name: tk-multi-launchapp
-  version: v0.12.1
+  version: v0.12.2
 common.apps.tk-multi-reviewsubmission.location:
   type: app_store
   name: tk-multi-reviewsubmission
@@ -67,5 +67,5 @@ common.apps.tk-shotgun-launchfolder.location:
 common.apps.tk-shotgun-launchvredreview.location:
   type: app_store
   name: tk-shotgun-launchvredreview
-  version: v1.1.2
+  version: v1.1.3
 common.apps.tk-multi-publish2.help_url: https://help.autodesk.com/view/SGSUB/ENU/?guid=SG_Supervisor_Artist_sa_integrations_sa_integrations_user_guide_html#the-publisher

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -15,47 +15,47 @@
 common.engines.tk-3dsmaxplus.location:
   type: app_store
   name: tk-3dsmaxplus
-  version: v0.6.1
+  version: v0.6.2
 common.engines.tk-3dsmax.location:
   type: app_store
   name: tk-3dsmax
-  version: v1.2.2
+  version: v1.2.4
 common.engines.tk-houdini.location:
   type: app_store
   name: tk-houdini
-  version: v1.8.2
+  version: v1.8.3
 common.engines.tk-maya.location:
   type: app_store
   name: tk-maya
-  version: v0.11.2
+  version: v0.11.4
 common.engines.tk-nuke.location:
   type: app_store
   name: tk-nuke
-  version: v0.14.3
+  version: v0.14.4
 common.engines.tk-photoshopcc.location:
   type: app_store
   name: tk-photoshopcc
-  version: v1.9.1
+  version: v1.9.2
 common.engines.tk-aftereffects.location:
   type: app_store
   name: tk-aftereffects
-  version: v0.3.1
+  version: v0.3.2
 common.engines.tk-flame.location:
   type: app_store
   name: tk-flame
-  version: v1.17.2
+  version: v1.17.3
 common.engines.tk-alias.location:
   type: app_store
   name: tk-alias
-  version: v2.1.3
+  version: v2.1.5
 common.engines.tk-vred.location:
   type: app_store
   name: tk-vred
-  version: v2.1.3
+  version: v2.1.4
 common.engines.tk-desktop.location:
   type: app_store
   name: tk-desktop
-  version: v2.6.2
+  version: v2.6.3
 common.engines.tk-desktop2.location:
   type: app_store
   name: tk-desktop2
@@ -63,8 +63,8 @@ common.engines.tk-desktop2.location:
 common.engines.tk-shell.location:
   type: app_store
   name: tk-shell
-  version: v0.9.1
+  version: v0.9.2
 common.engines.tk-shotgun.location:
   type: app_store
   name: tk-shotgun
-  version: v0.10.1
+  version: v0.10.2

--- a/env/includes/common/frameworks.yml
+++ b/env/includes/common/frameworks.yml
@@ -17,10 +17,10 @@ frameworks:
     location:
       type: app_store
       name: tk-framework-adobe
-      version: v1.1.4
+      version: v1.1.5
   tk-framework-qtwidgets_v2.x.x:
     location:
-      version: v2.10.2
+      version: v2.10.3
       type: app_store
       name: tk-framework-qtwidgets
   tk-framework-shotgunutils_v4.x.x:
@@ -30,12 +30,12 @@ frameworks:
       name: tk-framework-shotgunutils
   tk-framework-shotgunutils_v5.x.x:
     location:
-      version: v5.8.4
+      version: v5.8.5
       type: app_store
       name: tk-framework-shotgunutils
   tk-framework-adminui_v0.x.x:
     location:
-      version: v0.7.1
+      version: v0.7.2
       type: app_store
       name: tk-framework-adminui
   tk-framework-widget_v1.x.x:
@@ -45,21 +45,21 @@ frameworks:
       name: tk-framework-widget
   tk-framework-desktopserver_v1.x.x:
     location:
-      version: v1.5.2
+      version: v1.5.3
       type: app_store
       name: tk-framework-desktopserver
   tk-framework-desktopclient_v0.x.x:
     location:
-      version: v0.3.1
+      version: v0.3.2
       type: app_store
       name: tk-framework-desktopclient
   tk-framework-aliastranslations_v0.x.x:
     location:
-      version: v0.2.1
+      version: v0.2.2
       type: app_store
       name: tk-framework-aliastranslations
   tk-framework-lmv_v0.x.x:
     location:
-      version: v0.2.1
+      version: v0.2.2
       type: app_store
       name: tk-framework-lmv

--- a/env/includes/unreal/frameworks.yml
+++ b/env/includes/unreal/frameworks.yml
@@ -6,7 +6,7 @@
 frameworks:
     tk-framework-unrealqt_v1.x.x:
       location:
-        version: v1.2.8
-        type: git
-        path: git@github.com:GPLgithub/tk-framework-unrealqt.git
-#        path: git@github.com:ue4plugins/tk-framework-unrealqt.git
+        version: v1.2.0
+        type: github_release
+        organization: ue4plugins
+        repository: tk-framework-unrealqt

--- a/env/includes/unreal/frameworks.yml
+++ b/env/includes/unreal/frameworks.yml
@@ -6,7 +6,8 @@
 frameworks:
     tk-framework-unrealqt_v1.x.x:
       location:
-        version: v1.2.0
+        version: v1.3.0
         type: github_release
-        organization: ue4plugins
+        organization: GPLgithub
+        # organization: ue4plugins
         repository: tk-framework-unrealqt


### PR DESCRIPTION
Allowed bootstrap hook to accept git or `github_release` descriptor.
Updated bundles from TK basic v1.4.5.
Updated tk-framework-unrealqt descriptor to a `github_release`.
Updated tk-framework-unrealqt release to v1.3.0.

⚠️ The tk-framework-unrealqt v1.3.0 release must be created in https://github.com/ue4plugins/tk-framework-unrealqt before making these changes live.